### PR TITLE
refactor(hf-models): export hf module without the need for deps

### DIFF
--- a/dsp/modules/__init__.py
+++ b/dsp/modules/__init__.py
@@ -1,6 +1,6 @@
 from .cache_utils import *
 from .gpt3 import *
-# from .hf import HFModel
+from .hf import HFModel
 from .colbertv2 import ColBERTv2
 from .sentence_vectorizer import *
 from .cohere import *

--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -1,7 +1,4 @@
 from typing import Optional, Literal
-
-from transformers import AutoModelForSeq2SeqLM, AutoModelForCausalLM, AutoTokenizer
-
 from dsp.modules.lm import LM
 
 
@@ -32,10 +29,16 @@ class HFModel(LM):
         Args:
             model (str): HF model identifier to load and use
             checkpoint (str, optional): load specific checkpoints of the model. Defaults to None.
-            is_client (bool, optional): whether to use hf client or load from local. Defaults to False.
+            is_client (bool, optional): whether to access models via client. Defaults to False.
             hf_device_map (str, optional): HF config strategy to load the model. 
                 Recommeded to use "auto", which will help loading large models using accelerate. Defaults to "auto".
         """
+        try:
+            from transformers import AutoModelForSeq2SeqLM, AutoModelForCausalLM, AutoTokenizer
+        except ImportError as exc:
+            raise ModuleNotFoundError(
+                "You need to install Hugging Face transformers library to use HF models."
+            ) from exc
         super().__init__(model)
         self.provider = "hf"
         self.is_client = is_client

--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -48,7 +48,7 @@ class HFModel(LM):
                 self.model = AutoModelForSeq2SeqLM.from_pretrained(
                     model if checkpoint is None else checkpoint,
                     device_map=hf_device_map
-                ).to("cpu")
+                )
                 self.drop_prompt_from_output = False
             except ValueError:
                 self.model = AutoModelForCausalLM.from_pretrained(

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -1,9 +1,6 @@
-import functools
 import requests
 
-from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
 from dsp.modules.hf import HFModel
-from dsp.utils import dotdict
 
 
 class HFModelClient(HFModel):


### PR DESCRIPTION
Addresses #40 and our previous issues of not wanting hf transformers to be a dependency for dsp.

minor bug fix on using hf models on cpu.