### PR TITLE
feature(search): sbert re-ranker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 *.json
 !/data/*.json
 /dist/
+**/*.pkl

--- a/dsp/modules/__init__.py
+++ b/dsp/modules/__init__.py
@@ -4,3 +4,4 @@ from .hf import HFModel
 from .colbertv2 import ColBERTv2
 from .sentence_vectorizer import *
 from .cohere import *
+from .sbert import *

--- a/dsp/modules/sbert.py
+++ b/dsp/modules/sbert.py
@@ -1,0 +1,16 @@
+class SentenceTransformersCrossEncoder:
+    """Wrapper for sentence-transformers cross-encoder model.
+    """
+    def __init__(
+        self, model_name_or_path: str = "cross-encoder/ms-marco-MiniLM-L-12-v2"
+    ):
+        try:
+            from sentence_transformers.cross_encoder import CrossEncoder
+        except ImportError:
+            raise ModuleNotFoundError(
+                "You need to install sentence-transformers library to use SentenceTransformersCrossEncoder."
+            )
+        self.model = CrossEncoder(model_name_or_path)
+
+    def __call__(self, query: str, passage: list[str]) -> list[float]:
+        return self.model.predict([[query, p] for p in passage]).tolist()

--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -1,3 +1,4 @@
+import numpy as np
 import dsp
 
 
@@ -7,8 +8,32 @@ def retrieve(query: str, k: int) -> list[str]:
         raise AssertionError("No RM is loaded.")
     passages = dsp.settings.rm(query, k=k)
     passages = [psg.long_text for psg in passages]
+    
+    if dsp.settings.reranker:
+        passages_cs_scores = dsp.settings.reranker(query, passages)
+        passages_cs_scores_sorted = np.argsort(passages_cs_scores)[::-1]
+        passages = [passages[idx] for idx in passages_cs_scores_sorted]
 
     return passages
+
+
+def retrieveRerankEnsemble(queries: list[str], k: int) -> list[str]:
+    if not (dsp.settings.rm and dsp.settings.reranker):
+        raise AssertionError("Both RM and Reranker are needed to retrieve & re-rank.")
+    print("reranking")
+    queries = [q for q in queries if q]
+    passages = {}
+    for query in queries:
+        retrieved_passages = dsp.settings.rm(query, k=k*3)
+        passages_cs_scores = dsp.settings.reranker(query, [psg.long_text for psg in retrieved_passages])
+        for idx in np.argsort(passages_cs_scores)[::-1]:
+            psg = retrieved_passages[idx]
+            passages[psg.long_text] = passages.get(psg.long_text, []) + [
+                passages_cs_scores[idx]
+            ]
+
+    passages = [(np.average(score), text) for text, score in passages.items()]
+    return [text for _, text in sorted(passages, reverse=True)[:k]]
 
 
 def retrieveEnsemble(queries: list[str], k: int, by_prob: bool = True) -> list[str]:
@@ -17,7 +42,8 @@ def retrieveEnsemble(queries: list[str], k: int, by_prob: bool = True) -> list[s
     """
     if not dsp.settings.rm:
         raise AssertionError("No RM is loaded.")
-
+    if dsp.settings.reranker:
+        return retrieveRerankEnsemble(queries, k)
     queries = [q for q in queries if q]
 
     passages = {}

--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -20,7 +20,6 @@ def retrieve(query: str, k: int) -> list[str]:
 def retrieveRerankEnsemble(queries: list[str], k: int) -> list[str]:
     if not (dsp.settings.rm and dsp.settings.reranker):
         raise AssertionError("Both RM and Reranker are needed to retrieve & re-rank.")
-    print("reranking")
     queries = [q for q in queries if q]
     passages = {}
     for query in queries:

--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -17,6 +17,9 @@ class Settings(object):
             cls._instance = super().__new__(cls)
             cls._instance.stack = []
 
+            #  TODO: remove first-class support for re-ranker and potentially combine with RM to form a pipeline of sorts
+            #  eg: RetrieveThenRerankPipeline(RetrievalModel, Reranker)
+            #  downstream operations like dsp.retrieve would use configs from the defined pipeline.
             config = dotdict(
                 lm=None,
                 rm=None,

--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -1,4 +1,3 @@
-from typing import Callable, Optional
 from contextlib import contextmanager
 from dsp.utils.utils import dotdict
 
@@ -21,6 +20,7 @@ class Settings(object):
             config = dotdict(
                 lm=None,
                 rm=None,
+                reranker=None,
                 compiled_lm=None,
                 force_reuse_cached_compilation=False,
                 compiling=False,

--- a/intro.ipynb
+++ b/intro.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,7 +35,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -79,7 +76,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -109,7 +105,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -140,7 +135,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -166,7 +160,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -188,7 +181,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -215,7 +207,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -277,7 +268,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -432,7 +422,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -466,7 +455,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -490,7 +478,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -572,7 +559,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -730,7 +716,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -765,7 +750,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -801,7 +785,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -891,7 +874,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1042,7 +1024,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1086,7 +1067,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1111,7 +1091,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1159,7 +1138,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1303,7 +1281,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1461,7 +1438,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1475,7 +1451,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1514,7 +1489,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1934,7 +1908,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2171,7 +2144,13 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2196,7 +2175,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2211,11 +2189,73 @@
    "source": [
     "# Program 4 with max_hops=4 and automatic stopping."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Additional Capabilities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## more LLMs for use\n",
+    "Eventhough the most quality tested model is openai text-davinci, we also offer support for `openai chatgpt, cohere, and hf models`.\n",
+    "\n",
+    "`Note:` The quality and stability might be different based on the provider and the model. Please report any bugs that you come across."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initializing chatgpt\n",
+    "\n",
+    "lm = dsp.GPT3(model='gpt-3.5-turbo', api_key=openai_key, model_type='chat')\n",
+    "\n",
+    "# initializing cohere\n",
+    "\n",
+    "lm = dsp.Cohere(model='command-xlarge-nightly')\n",
+    "\n",
+    "# initializing hf models\n",
+    "\n",
+    "lm = dsp.HFModel(model=\"google/flan-t5-base\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Re-Ranker\n",
+    "\n",
+    "You could also construct powerful retrieval programs that uses both `retriever and re-ranker model`.\n",
+    "\n",
+    "Currently, we support `Sentence-Transformers cross-encoder` for reranking, and an example initialisation and usage is provided below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sbert_reranker = dsp.SentenceTransformersCrossEncoder(\"cross-encoder/ms-marco-MiniLM-L-12-v2\")\n",
+    "\n",
+    "dsp.settings.configure(lm=lm, rm=rm, reranker=sbert_reranker)\n",
+    "\n",
+    "# dsp.retrieve, and retrieveEnsemble already takes care of retrieving and re-ranking based on initiated rm, and reranker.\n",
+    "\n",
+    "reranked_passages = dsp.retrieve(\"When was the creator of Hadoop given an award?\", k=3)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2229,15 +2269,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "de72ef8826336f005e74d4a3f2b2dfb9239c3f097fd15aff69f3f6a4fc3bd8b8"
    }
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The PR does the below
- Introduces re-ranker that couples with existing retrieval. 
- updated the intro notebook for usage

```
sbert_reranker = dsp.SentenceTransformersCrossEncoder("cross-encoder/ms-marco-MiniLM-L-12-v2")

dsp.settings.configure(lm=lm, rm=rm, reranker=sbert_reranker)

# dsp.retrieve, and retrieveEnsemble already takes care of retrieving and re-ranking based on initiated rm, and reranker.

reranked_passages = dsp.retrieve("When was the creator of Hadoop given an award?", k=3)
```